### PR TITLE
Implement ability to add contact to a pipeline from the contact index pa...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'hashie'
 gem 'foundation-rails'
 gem 'angularjs-rails'
 gem 'ng-rails-csrf'
+gem 'underscore-rails'
 
 group :test do
   gem 'vcr', '~> 2.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    underscore-rails (1.6.0)
     vcr (2.6.0)
     webmock (1.13.0)
       addressable (>= 2.2.7)
@@ -223,5 +224,6 @@ DEPENDENCIES
   sass-rails (~> 4.0.0)
   sdoc
   uglifier (>= 1.3.0)
+  underscore-rails
   vcr (~> 2.6.0)
   webmock (~> 1.13.0)

--- a/app/assets/javascripts/angular/app.js.erb
+++ b/app/assets/javascripts/angular/app.js.erb
@@ -43,7 +43,6 @@ var app = angular
       templateUrl: "<%= asset_path('angular/templates/createFields.html') %>",
       controller: 'StagesCtrl'
     })
-    // Create new route for /pipeline/:contact_id
     .when('/contacts', {
       templateUrl: "<%= asset_path('angular/templates/contacts.html') %>",
       controller: 'ContactsCtrl'

--- a/app/assets/javascripts/angular/controllers/contact_ngcontroller.js
+++ b/app/assets/javascripts/angular/controllers/contact_ngcontroller.js
@@ -1,8 +1,10 @@
 //this controller gives scope to the dom template "contacts.html" and adds
 //functionality for manually adding contacts to the dom and db simultaneously
+'use strict';
+
 app.controller('ContactsCtrl',
-  ['$scope', '$resource', 'ContactsRsc',
-  function($scope, $resource, ContactsRsc) {
+  ['$scope', '$resource', 'ContactsRsc', 'PipelinesRsc', 'ContactsBoxRsc',
+  function($scope, $resource, ContactsRsc, PipelinesRsc, ContactsBoxRsc) {
     $scope.buttonClicked = false;
     $scope.showContactForm = function(){
       $scope.buttonClicked = true;
@@ -10,6 +12,20 @@ app.controller('ContactsCtrl',
     $scope.hideContactForm = function(){
       $scope.buttonClicked = false;
     };
+
+    // An array of all the pipelines a contact is not in
+    var setUnaddedPipelinesForContacts = function(contacts, pipelines) {
+      _.each(contacts, function(contact) {
+        var contactPipelineIds = _.map(contact.pipelines, function(pipeline) { return pipeline.id });
+        var unaddedPipelines = _.reject(pipelines, function(pipeline) {
+          return contactPipelineIds.indexOf(pipeline.id) >= 0;
+        });
+        contact.unaddedPipelines = unaddedPipelines;
+        // console.log(unaddedPipelines);
+      });
+    }
+
+    $scope.pipelines = PipelinesRsc.pipersc.query();
     $scope.contacts = ContactsRsc.query();
     $scope.newContact = {};
     $scope.addNewContact = function(){
@@ -19,5 +35,40 @@ app.controller('ContactsCtrl',
       });
     };
 
+    $scope.pipelines.$promise.then(function(result) {
+      $scope.pipelines = result;
+      return $scope.contacts.$promise;
+    }).then(function(result) {
+      $scope.contacts = result;
+      setUnaddedPipelinesForContacts($scope.contacts, $scope. pipelines);
+    });
+
+    $scope.addContactToPipeline = function(pipeline, contact) {
+      // console.log(pipeline);
+      // console.log(contact);
+      var data = {
+        pipeline_id: pipeline.id,
+        contact_id: contact.id
+      };
+      contact.pipelines.push(pipeline);
+      var index = contact.unaddedPipelines.indexOf(pipeline);
+      contact.unaddedPipelines.splice(index, 1);
+      ContactsBoxRsc.save(data);
+      console.log(data);
+    }
+
+    $scope.removeContactFromPipeline = function(pipeline, contact) {
+      // console.log(pipeline);
+      // console.log(contact);
+      var data = {
+        pipeline_id: pipeline.id,
+        id: contact.id
+      };
+      var index = contact.pipelines.indexOf(pipeline);
+      contact.pipelines.splice(index, 1);
+      contact.unaddedPipelines.push(pipeline);
+      ContactsBoxRsc.remove(data);
+      console.log(data);
+    }
 
   }]);

--- a/app/assets/javascripts/angular/controllers/contact_ngcontroller.js
+++ b/app/assets/javascripts/angular/controllers/contact_ngcontroller.js
@@ -1,5 +1,6 @@
-//this controller gives scope to the dom template "contacts.html" and adds
-//functionality for manually adding contacts to the dom and db simultaneously
+// This controller gives scope to the dom template "contacts.html" and adds
+// functionality for manually adding contacts to the dom and db simultaneously.
+// It also contains the logic for adding/removing a contact to/from a pipeline.
 'use strict';
 
 app.controller('ContactsCtrl',
@@ -13,7 +14,8 @@ app.controller('ContactsCtrl',
       $scope.buttonClicked = false;
     };
 
-    // An array of all the pipelines a contact is not in
+    // This function finds all the pipelines a contact is NOT in and
+    // outputs the result to an array.
     var setUnaddedPipelinesForContacts = function(contacts, pipelines) {
       _.each(contacts, function(contact) {
         var contactPipelineIds = _.map(contact.pipelines, function(pipeline) { return pipeline.id });
@@ -21,7 +23,6 @@ app.controller('ContactsCtrl',
           return contactPipelineIds.indexOf(pipeline.id) >= 0;
         });
         contact.unaddedPipelines = unaddedPipelines;
-        // console.log(unaddedPipelines);
       });
     }
 
@@ -44,31 +45,25 @@ app.controller('ContactsCtrl',
     });
 
     $scope.addContactToPipeline = function(pipeline, contact) {
-      // console.log(pipeline);
-      // console.log(contact);
+      contact.pipelines.push(pipeline);
+      var index = contact.unaddedPipelines.indexOf(pipeline);
+      contact.unaddedPipelines.splice(index, 1);
       var data = {
         pipeline_id: pipeline.id,
         contact_id: contact.id
       };
-      contact.pipelines.push(pipeline);
-      var index = contact.unaddedPipelines.indexOf(pipeline);
-      contact.unaddedPipelines.splice(index, 1);
       ContactsBoxRsc.save(data);
-      console.log(data);
     }
 
     $scope.removeContactFromPipeline = function(pipeline, contact) {
-      // console.log(pipeline);
-      // console.log(contact);
+      var index = contact.pipelines.indexOf(pipeline);
+      contact.pipelines.splice(index, 1);
+      contact.unaddedPipelines.push(pipeline);
       var data = {
         pipeline_id: pipeline.id,
         id: contact.id
       };
-      var index = contact.pipelines.indexOf(pipeline);
-      contact.pipelines.splice(index, 1);
-      contact.unaddedPipelines.push(pipeline);
       ContactsBoxRsc.remove(data);
-      console.log(data);
     }
 
   }]);

--- a/app/assets/javascripts/angular/controllers/pipeline_details_ngcontroller.js
+++ b/app/assets/javascripts/angular/controllers/pipeline_details_ngcontroller.js
@@ -12,7 +12,7 @@ app.controller('PipelineDetailsCtrl',
     $scope.contact.showEdit = false;
     // $scope.draggable = true;
 
-    PipelinesRsc.getPipe({Id: $routeParams.id})
+    PipelinesRsc.pipersc.get({Id: $routeParams.id})
       .$promise.then(function(data){
         $scope.pipeline = data;
     });

--- a/app/assets/javascripts/angular/controllers/pipeline_index_ngcontroller.js
+++ b/app/assets/javascripts/angular/controllers/pipeline_index_ngcontroller.js
@@ -4,10 +4,18 @@ app.controller('PipelineIndexCtrl',
     $scope.newPipeline = false;
     $scope.pipelineName = "";
 
-    var updatePipes = function(){
-      $scope.pipelineList = PipelinesRsc.get();
-    };
-    updatePipes();
+    $scope.$watchCollection(function(){
+      return PipelinesRsc.pipeList;
+    },
+    function(pipeList){
+      $scope.pipelineList = pipeList;
+    });
+
+    $scope.pipelineList = PipelinesRsc.pipeList;
+    // var updatePipes = function(){
+    //   $scope.pipelineList = PipelinesRsc.get();
+    // };
+    // updatePipes();
 
     $scope.namePipeline = function() {
       $scope.newPipeline = true;

--- a/app/assets/javascripts/angular/services/contacts_box_rsc.js
+++ b/app/assets/javascripts/angular/services/contacts_box_rsc.js
@@ -3,9 +3,6 @@ app.factory("ContactsBoxRsc", function ($resource) {
         "/pipelines/:pipeline_id/contacts/:id.json",
         {pipeline_id: '@pipeline_id', id: '@id'},
         {
-          get: {
-            method: 'GET'
-          },
           update: {
             method: 'PUT'
           }

--- a/app/assets/javascripts/angular/services/pipeline_rsc.js
+++ b/app/assets/javascripts/angular/services/pipeline_rsc.js
@@ -1,18 +1,26 @@
 app.factory("PipelinesRsc", function ($resource) {
-    return $resource(
+
+    var pipeList = [];
+
+    var pipersc = $resource(
         "/pipelines/:Id.json",
         {Id: "@Id" },
         {
-            'get': {
-              method:'GET',
-              isArray:true,
-            },
-            'getPipe':{
-              method:'GET'
-            },
-            'createPipe':{
-              method:"POST",
-            }
+          'createPipe':{
+            method:"POST",
+          }
         }
     );
+
+    var updatePipeList = function(){
+      pipeList = pipersc.query()
+    };
+
+    updatePipeList();
+
+    return {
+      pipersc   : pipersc,
+      updatePipeList : updatePipeList,
+      pipeList  : pipeList
+    }
 });

--- a/app/assets/javascripts/angular/templates/contacts.html
+++ b/app/assets/javascripts/angular/templates/contacts.html
@@ -8,19 +8,23 @@
   <div ng-click="hideContactForm()" class="button">Hide Contact Form</div>
 </form>
 <div class="row">
-  <div class="panel columns" ng-repeat="contact in contacts">
+  <div ng-repeat="contact in contacts" class="panel columns">
     <h3> {{ contact.name }} </h3>
     <p> {{ contact.email }} <p>
     <p> {{ contact.city }} </p>
     <p> {{ contact.phonenumber }} </p>
     <h3> Pipelines </h3>
-    <span class="success radius label"> Admissions </span><br>
-    <a href="#" data-dropdown="drop1" class="button dropdown">Pipeline</a><br>
-    <ul id="drop1" data-dropdown-content class="f-dropdown">
-      <li><a href="#">This is a link</a></li>
-      <li><a href="#">This is another</a></li>
-      <li><a href="#">Yet another</a></li>
-    </ul>
-    <input type="submit" class="button" value="Add To Pipeline" />
+    <div class="contact pipelines" ng-repeat="pipeline in contact.pipelines">
+      <span class="success radius label"> {{pipeline.name}} </span>
+      <button ng-click="removeContactFromPipeline(pipeline, contact)">Remove</button>
+    </div>
+    <form ng-submit="addContactToPipeline(selectedPipeline, contact)">
+      <select
+        ng-model="selectedPipeline"
+        ng-options="pipeline.name for pipeline in contact.unaddedPipelines">
+      </select>
+      <input type="submit" class="button" value="Add To Pipeline" />
+    </form>
   </div>
 </div>
+

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require underscore
 //= require jquery
 //= require jquery-ui
 //= require jquery_ujs

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,8 @@
   font-size: 1em;
   top: 0; left: 0; bottom: 0; right: 0;
 }
+
+.success.radius.label {
+  display: inline-block;
+  width: auto;
+}

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -2,7 +2,15 @@ class ContactsController < ApplicationController
   respond_to :json, :html
   # before_filter :logged_in?
   # before_filter :admin?
-  def new
+
+  def index
+    # Index to show contacts
+    result = RetrieveAllContactInfo.run(params)
+    if result.success?
+      respond_with result.contacts.map(&:to_h)
+    else
+      respond_with(result.error, status: :unprocessable_entity)
+    end
   end
 
   def create
@@ -12,8 +20,11 @@ class ContactsController < ApplicationController
     if results.success?
       respond_with results.contact
     else
-      respond_with results.error
+      respond_with(result.error, status: :unprocessable_entity)
     end
+  end
+
+  def new
   end
 
   def show
@@ -23,16 +34,6 @@ class ContactsController < ApplicationController
       respond_with show_contact.to_h
     elsif show_contact.error == :no_box_found
       respond_with({errors: ["Could not find proper Box"]}, status: :unprocessable_entity)
-    end
-  end
-
-  def index
-    # Index to show contacts
-    result = RetrieveAllContactInfo.run(params)
-    if result.success?
-      respond_with result.contacts.map(&:to_h)
-    else
-      respond_with(result.error, status: :unprocessable_entity)
     end
   end
 

--- a/app/controllers/pipeline_contacts_controller.rb
+++ b/app/controllers/pipeline_contacts_controller.rb
@@ -1,0 +1,39 @@
+class PipelineContactsController < ApplicationController
+  respond_to :json, :html
+
+  def index
+    # Index for all contacts
+    result = RetrieveBoxesForPipeline.run({pipeline_id: params[:pipeline_id]})
+    if result.success?
+      respond_with result.contacts.map(&:to_h)
+    else
+      respond_with(result.error, status: :unprocessable_entity)
+    end
+  end
+
+  def create
+    # Finds the first stage in a given pipeline
+    first_stage_in_pipeline = Pipeline.find(params[:pipeline_id]).stages.order(:pipeline_location).first
+    # Creates a box with all the required parameters
+    result = CreateBox.run(contact_id: contact_params[:contact_id], stage_id: first_stage_in_pipeline.id, pipeline_id: box_params[:pipeline_id], pipeline_location: first_stage_in_pipeline.pipeline_location)
+    if result.success?
+      respond_with result.box
+    else
+      respond_with result.error
+    end
+  end
+
+  def destroy
+    Contact.find(contact_params[:id]).boxes.find_by(pipeline_id: box_params[:pipeline_id]).destroy
+  end
+
+  private
+
+  def box_params
+    params.permit(:id, :contact_id, :stage_id, :pipeline_id)
+  end
+
+  def contact_params
+    params.permit(:id, :contact_id, :name, :email, :phonenumber, :city)
+  end
+end

--- a/app/services/Contact/retrieve_all_contact_info.rb
+++ b/app/services/Contact/retrieve_all_contact_info.rb
@@ -1,79 +1,18 @@
-#
-# This constructs a object to be sent to the client with with detailed information
-# about the contact that are part of a given pipeline.  This information includes two types
-# Basic and Complex.
-# Basic Information comes from the: Contacts Table
-# Complex Information comes from: Boxes, BoxFields, Fields Tables
-#
-# Example Script Call
-#   RetrieveAllContactInfo.run(pipeline_id: 7)
-# Example Output
-#   Returns OStruct, for ease of use.
-#   { success?: true,
-#     contacts: [
-#       { name: "Doug",
-#         email: "doug@doug.com",
-#         id: "7",
-#         stage_id: "16"
-#         'field1_name' : field1_value,
-#         'fieldn_name': fieldn_value,
-#         ...more fields...
-#        },
-#         ...Another Contact...
-#     ]
-#   }
-#
-# You can also use this script to get generic information about the contact
-# that is not specific to the pipeline.
+# Retrieves all contacts from databases, but also
+# injects data about which pipelines the contact is
+# a part of.
+
 class RetrieveAllContactInfo < TransactionScript
   def run(params)
-    pipeline_id = params[:pipeline_id]
-
-    if pipeline_id.nil? || pipeline_id == ""
-      # If the user hasn't passed in a pipeline id, don't retrieve pipeline
-      # specific information, but instead gather information about
-      # all of the pipelines the contact is in.
-      contacts = Contact.all.map do |contact|
-        # Convert to OpenStruct for ease of use
-        contact_struct = OpenStruct.new(contact.serializable_hash)
-        add_pipeline_info_to_contact(contact, contact_struct)
-        contact_struct
-      end
-
-      return success(contacts: contacts)
-    end
-
-    pipeline = Pipeline.where(id: pipeline_id).first
-
-    if pipeline.nil?
-      return failure(:invalid_pipeline_id)
-    end
-
-    fields = retrieve_fields(pipeline)
-
-    # Returning each contact's information
-    # Gathering - basic info, stage_id, fields
-    contacts = pipeline.boxes.map do |box|
-      contact = box.contact
+    # Gather all contact information, but also send data about the pipelines
+    contacts = Contact.all.map do |contact|
       # Convert to OpenStruct for ease of use
-      contact = OpenStruct.new(contact.serializable_hash)
-      contact.stage_id = box.stage_id
-      add_fields_to_contact(contact, fields, box)
-      contact
+      contact_struct = OpenStruct.new(contact.serializable_hash)
+      add_pipeline_info_to_contact(contact, contact_struct)
+      contact_struct
     end
 
-    success(contacts: contacts)
-  end
-
-  def retrieve_fields(pipeline)
-    pipeline.fields
-  end
-
-  def add_fields_to_contact(contact, fields, box)
-    fields.each do |field|
-      box_field = BoxField.where(field_id: field.id, box_id: box.id).first
-      contact[field.field_name] = box_field.value
-    end
+    return success(contacts: contacts)
   end
 
   # Retrieves information about which pipelines the contact is in.

--- a/app/services/Pipeline/add_contact_to_pipeline.rb
+++ b/app/services/Pipeline/add_contact_to_pipeline.rb
@@ -2,6 +2,7 @@ class AddContactToPipeline < TransactionScript
   def run(params)
     # Add contact to a pipeline via the ContactPipelines table
     result = Box.create(params)
+    # if stage id == null then populate with first stage # pipeline.stages.first
     return success(contact: result)
   end
 end

--- a/app/services/Pipeline/add_contact_to_pipeline.rb
+++ b/app/services/Pipeline/add_contact_to_pipeline.rb
@@ -2,7 +2,6 @@ class AddContactToPipeline < TransactionScript
   def run(params)
     # Add contact to a pipeline via the ContactPipelines table
     result = Box.create(params)
-    # if stage id == null then populate with first stage # pipeline.stages.first
     return success(contact: result)
   end
 end

--- a/app/services/retrieve_boxes_for_pipeline.rb
+++ b/app/services/retrieve_boxes_for_pipeline.rb
@@ -1,0 +1,72 @@
+#
+# This constructs a object to be sent to the client with with detailed information
+# about the contact that are part of a given pipeline.  This information includes two types
+# Basic and Complex.
+# Basic Information comes from the: Contacts Table
+# Complex Information comes from: Boxes, BoxFields, Fields Tables
+#
+# Example Script Call
+#   RetrieveBoxesForPipeline.run(pipeline_id: 7)
+# Example Output
+#   Returns OStruct, for ease of use.
+#   { success?: true,
+#     contacts: [
+#       { name: "Doug",
+#         email: "doug@doug.com",
+#         id: "7",
+#         stage_id: "16"
+#         'field1_name' : field1_value,
+#         'fieldn_name': fieldn_value,
+#         ...more fields...
+#        },
+#         ...Another Contact...
+#     ]
+#   }
+
+class RetrieveBoxesForPipeline < TransactionScript
+  def run(params)
+    pipeline_id = params[:pipeline_id]
+
+    if pipeline_id.nil? || pipeline_id == ""
+      return failure(:no_pipeline_given)
+    end
+
+    pipeline = Pipeline.where(id: pipeline_id).first
+
+    if pipeline.nil?
+      return failure(:invalid_pipeline_id)
+    end
+
+    fields = retrieve_fields(pipeline)
+
+    # Returning each contact's information
+    # Gathering - basic info, stage_id, fields
+    contacts = pipeline.boxes.map do |box|
+      contact = box.contact
+      # Convert to OpenStruct for ease of use
+      contact = OpenStruct.new(contact.serializable_hash)
+      contact.stage_id = box.stage_id
+      add_fields_to_contact(contact, fields, box)
+      contact
+    end
+
+    success(contacts: contacts)
+  end
+
+  def retrieve_fields(pipeline)
+    pipeline.fields
+  end
+
+  def add_fields_to_contact(contact, fields, box)
+    fields.each do |field|
+      box_field = BoxField.where(field_id: field.id, box_id: box.id).first
+      contact[field.field_name] = box_field.value
+    end
+  end
+
+  # Retrieves information about which pipelines the contact is in.
+  def add_pipeline_info_to_contact(contact, contact_struct)
+    pipelines = contact.pipelines
+    contact_struct.pipelines = pipelines.to_a.map(&:serializable_hash)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,12 +19,11 @@ Crm::Application.routes.draw do
 
   resources :pipelines do
     resources :stages, :defaults => { :format => :json }
-    resources :contacts do
+    resources :contacts, controller: 'pipeline_contacts' do
       resources :notes, :defaults => { :format => :json }
     end
     resources :boxes
     resources :users
-
     resources :fields, :defaults => { :format => :json }
 
     get 'users', to: 'pipelines#retrieve_collaborators'

--- a/spec/services/retrieve_all_contact_info_spec.rb
+++ b/spec/services/retrieve_all_contact_info_spec.rb
@@ -3,116 +3,47 @@ require 'spec_helper'
 describe RetrieveAllContactInfo do
   it_behaves_like('TransactionScripts')
 
-  context "no pipeline ID given" do
-    let!(:c1) {Contact.create(name: "Jack1", email: "j1@j.com", city: "sf", phonenumber: "1231")}
-    let!(:c2) {Contact.create(name: "Jack2", email: "j2@j.com", city: "atx", phonenumber: "1232")}
-    let!(:c3) {Contact.create(name: "Jack3", email: "j3@j.com", city: "atl", phonenumber: "1233")}
+  let!(:c1) {Contact.create(name: "Jack1", email: "j1@j.com", city: "sf", phonenumber: "1231")}
+  let!(:c2) {Contact.create(name: "Jack2", email: "j2@j.com", city: "atx", phonenumber: "1232")}
+  let!(:c3) {Contact.create(name: "Jack3", email: "j3@j.com", city: "atl", phonenumber: "1233")}
 
-    it "retrieves all contacts and associated data" do
-      result = RetrieveAllContactInfo.run({})
-      expect(result.success?).to eq(true)
-      expect(result.contacts.size).to eq(3)
-      expect(result.contacts[0].name).to eq(c1.name)
-      expect(result.contacts[1].name).to eq(c2.name)
-      expect(result.contacts[2].name).to eq(c3.name)
-    end
-
-    describe "retrieval of pipeline info" do
-      let(:p1) {Pipeline.create(name: "Pipeline1")}
-      let(:p2) {Pipeline.create(name: "Pipeline2")}
-
-      before do
-        AddContactToPipeline.run(contact_id: c1.id, pipeline_id: p1.id)
-        AddContactToPipeline.run(contact_id: c1.id, pipeline_id: p2.id)
-        AddContactToPipeline.run(contact_id: c2.id, pipeline_id: p2.id)
-      end
-
-      it "retrieves pipeline array of correct size" do
-        result = RetrieveAllContactInfo.run({})
-        expect(result.contacts[0].pipelines).to be_a(Array)
-        expect(result.contacts[0].pipelines.size).to eq(2)
-        expect(result.contacts[1].pipelines.size).to eq(1)
-        expect(result.contacts[2].pipelines.size).to eq(0)
-      end
-
-      it "retrieves pipelines that contact is part of" do
-        result = RetrieveAllContactInfo.run({})
-        expect(result.contacts[0].pipelines[0]["name"]).to eq(p1.name)
-        expect(result.contacts[0].pipelines[0]["id"]).to eq(p1.id)
-        expect(result.contacts[0].pipelines[1]["name"]).to eq(p2.name)
-        expect(result.contacts[0].pipelines[1]["id"]).to eq(p2.id)
-
-        expect(result.contacts[1].pipelines[0]["name"]).to eq(p2.name)
-        expect(result.contacts[1].pipelines[0]["id"]).to eq(p2.id)
-
-      end
-    end
+  it "retrieves all contacts and associated data" do
+    result = RetrieveAllContactInfo.run({})
+    expect(result.success?).to eq(true)
+    expect(result.contacts.size).to eq(3)
+    expect(result.contacts[0].name).to eq(c1.name)
+    expect(result.contacts[1].name).to eq(c2.name)
+    expect(result.contacts[2].name).to eq(c3.name)
   end
 
-  context "a pipeline ID is given" do
+  describe "retrieval of pipeline info" do
+    let(:p1) {Pipeline.create(name: "Pipeline1")}
+    let(:p2) {Pipeline.create(name: "Pipeline2")}
 
-    it "errors out with an invalid pipeline id" do
-      result = RetrieveAllContactInfo.run({pipeline_id: -1})
-      expect(result.success?).to eq(false)
-      expect(result.error).to eq(:invalid_pipeline_id)
+    before do
+      AddContactToPipeline.run(contact_id: c1.id, pipeline_id: p1.id)
+      AddContactToPipeline.run(contact_id: c1.id, pipeline_id: p2.id)
+      AddContactToPipeline.run(contact_id: c2.id, pipeline_id: p2.id)
     end
 
-    context "proper pipeline id given" do
-      let(:pipeline) { Pipeline.create(name: "My Pipeline") }
-      let(:params) { {pipeline_id: pipeline.id} }
+    it "retrieves pipeline array of correct size" do
+      result = RetrieveAllContactInfo.run({})
+      expect(result.contacts[0].pipelines).to be_a(Array)
+      expect(result.contacts[0].pipelines.size).to eq(2)
+      expect(result.contacts[1].pipelines.size).to eq(1)
+      expect(result.contacts[2].pipelines.size).to eq(0)
+    end
 
-      it "returns an empty array if there are no contacts" do
-        result = RetrieveAllContactInfo.run(params)
-        expect(result.success?).to eq(true)
-        expect(result.contacts).to eq([])
-      end
+    it "retrieves pipelines that contact is part of" do
+      result = RetrieveAllContactInfo.run({})
+      expect(result.contacts[0].pipelines[0]["name"]).to eq(p1.name)
+      expect(result.contacts[0].pipelines[0]["id"]).to eq(p1.id)
+      expect(result.contacts[0].pipelines[1]["name"]).to eq(p2.name)
+      expect(result.contacts[0].pipelines[1]["id"]).to eq(p2.id)
 
-      context "pipeline has contacts" do
-        let(:c1) {Contact.create(name: "Jack1", email: "j1@j.com", city: "sf", phonenumber: "1231")}
-        let(:c2) {Contact.create(name: "Jack2", email: "j2@j.com", city: "atx", phonenumber: "1232")}
-        let(:c3) {Contact.create(name: "Jack3", email: "j3@j.com", city: "atl", phonenumber: "1233")}
-        let(:field1) {Field.create(pipeline_id: pipeline.id, field_name: "Field 1", field_type: "String")}
-        let(:field2) {Field.create(pipeline_id: pipeline.id, field_name: "Field 2", field_type: "String")}
-        let(:stage1) {Stage.create(name: "First Stage", pipeline_id: pipeline.id)}
-        let(:stage2) {Stage.create(name: "Second Stage", pipeline_id: pipeline.id)}
-        let!(:box1) {Box.create(contact_id: c1.id, pipeline_id: pipeline.id, stage_id: stage1.id)}
-        let!(:box2) {Box.create(contact_id: c3.id, pipeline_id: pipeline.id, stage_id: stage2.id)}
-        let!(:box1_field1) {BoxField.create(field_id: field1.id, box_id: box1.id, value: "Contact 1 Field 1")}
-        let!(:box1_field2) {BoxField.create(field_id: field2.id, box_id: box1.id, value: "Contact 1 Field 2")}
-        let!(:box2_field1) {BoxField.create(field_id: field1.id, box_id: box2.id, value: "Contact 2 Field 1")}
-        let!(:box2_field2) {BoxField.create(field_id: field2.id, box_id: box2.id, value: "Contact 2 Field 2")}
+      expect(result.contacts[1].pipelines[0]["name"]).to eq(p2.name)
+      expect(result.contacts[1].pipelines[0]["id"]).to eq(p2.id)
 
-        it "has 2 contacts in the response" do
-          result = RetrieveAllContactInfo.run(params)
-          expect(result.success?).to eq(true)
-          expect(result.contacts.size).to eq(2)
-        end
-
-        it "includes the proper contact's info" do
-          result = RetrieveAllContactInfo.run(params)
-          basic_keys = [:name, :email, :id]
-          expect(result.contacts[0][:id]).to eq(c1.id)
-          expect(result.contacts[0].name).to eq(c1.name)
-          expect(result.contacts[0].email).to eq(c1.email)
-          expect(result.contacts[1].id).to eq(c3.id)
-          expect(result.contacts[1].name).to eq(c3.name)
-          expect(result.contacts[1].email).to eq(c3.email)
-        end
-
-        it "includes the contact's stage id" do
-          result = RetrieveAllContactInfo.run(params)
-          expect(result.contacts[0].stage_id).to eq(stage1.id)
-          expect(result.contacts[1].stage_id).to eq(stage2.id)
-        end
-
-        it "includes the contact's box fields" do
-          result = RetrieveAllContactInfo.run(params)
-          expect(result.contacts[0]["Field 1"]).to eq("Contact 1 Field 1")
-          expect(result.contacts[0]["Field 2"]).to eq("Contact 1 Field 2")
-          expect(result.contacts[1]["Field 1"]).to eq("Contact 2 Field 1")
-          expect(result.contacts[1]["Field 2"]).to eq("Contact 2 Field 2")
-        end
-      end
     end
   end
 end

--- a/spec/services/retrieve_boxes_for_pipeline_spec.rb
+++ b/spec/services/retrieve_boxes_for_pipeline_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe RetrieveBoxesForPipeline do
+  it_behaves_like('TransactionScripts')
+
+  context "no pipeline ID given" do
+    it "returns failure" do
+      result = RetrieveBoxesForPipeline.run({})
+      expect(result.success?).to eq(false)
+      expect(result.error).to eq(:no_pipeline_given)
+    end
+  end
+
+  context "a pipeline ID is given" do
+
+    it "errors out with an invalid pipeline id" do
+      result = RetrieveBoxesForPipeline.run({pipeline_id: -1})
+      expect(result.success?).to eq(false)
+      expect(result.error).to eq(:invalid_pipeline_id)
+    end
+
+    context "proper pipeline id given" do
+      let(:pipeline) { Pipeline.create(name: "My Pipeline") }
+      let(:params) { {pipeline_id: pipeline.id} }
+
+      it "returns an empty array if there are no contacts" do
+        result = RetrieveBoxesForPipeline.run(params)
+        expect(result.success?).to eq(true)
+        expect(result.contacts).to eq([])
+      end
+
+      context "pipeline has contacts" do
+        let(:c1) {Contact.create(name: "Jack1", email: "j1@j.com", city: "sf", phonenumber: "1231")}
+        let(:c2) {Contact.create(name: "Jack2", email: "j2@j.com", city: "atx", phonenumber: "1232")}
+        let(:c3) {Contact.create(name: "Jack3", email: "j3@j.com", city: "atl", phonenumber: "1233")}
+        let(:field1) {Field.create(pipeline_id: pipeline.id, field_name: "Field 1", field_type: "String")}
+        let(:field2) {Field.create(pipeline_id: pipeline.id, field_name: "Field 2", field_type: "String")}
+        let(:stage1) {Stage.create(name: "First Stage", pipeline_id: pipeline.id)}
+        let(:stage2) {Stage.create(name: "Second Stage", pipeline_id: pipeline.id)}
+        let!(:box1) {Box.create(contact_id: c1.id, pipeline_id: pipeline.id, stage_id: stage1.id)}
+        let!(:box2) {Box.create(contact_id: c3.id, pipeline_id: pipeline.id, stage_id: stage2.id)}
+        let!(:box1_field1) {BoxField.create(field_id: field1.id, box_id: box1.id, value: "Contact 1 Field 1")}
+        let!(:box1_field2) {BoxField.create(field_id: field2.id, box_id: box1.id, value: "Contact 1 Field 2")}
+        let!(:box2_field1) {BoxField.create(field_id: field1.id, box_id: box2.id, value: "Contact 2 Field 1")}
+        let!(:box2_field2) {BoxField.create(field_id: field2.id, box_id: box2.id, value: "Contact 2 Field 2")}
+
+        it "has 2 contacts in the response" do
+          result = RetrieveBoxesForPipeline.run(params)
+          expect(result.success?).to eq(true)
+          expect(result.contacts.size).to eq(2)
+        end
+
+        it "includes the proper contact's info" do
+          result = RetrieveBoxesForPipeline.run(params)
+          basic_keys = [:name, :email, :id]
+          expect(result.contacts[0][:id]).to eq(c1.id)
+          expect(result.contacts[0].name).to eq(c1.name)
+          expect(result.contacts[0].email).to eq(c1.email)
+
+          expect(result.contacts[1].id).to eq(c3.id)
+          expect(result.contacts[1].name).to eq(c3.name)
+          expect(result.contacts[1].email).to eq(c3.email)
+        end
+
+        it "includes the contact's stage id" do
+          result = RetrieveBoxesForPipeline.run(params)
+          expect(result.contacts[0].stage_id).to eq(stage1.id)
+          expect(result.contacts[1].stage_id).to eq(stage2.id)
+        end
+
+        it "includes the contact's box fields" do
+          result = RetrieveBoxesForPipeline.run(params)
+          expect(result.contacts[0]["Field 1"]).to eq("Contact 1 Field 1")
+          expect(result.contacts[0]["Field 2"]).to eq("Contact 1 Field 2")
+          expect(result.contacts[1]["Field 1"]).to eq("Contact 2 Field 1")
+          expect(result.contacts[1]["Field 2"]).to eq("Contact 2 Field 2")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
...ge

Built out view and routes

Implement ability to add contact to a pipeline from the contact index page

Add pipeline data to contact retrieval txs

Put pipeline list logic into new service, add pipeline labels to contacts template

Finish Angular frontend

Create destroy action in contacts controller to remove pipeline from contact

Add strong params for destroy action

Split contacts_controller into new control pipeline_contacts_controller, decouple specs, test

Add To Pipeline now persists contact's new pipeline in db

Refactoried txs, added comments

Finish Angular frontend

Create destroy action in contacts controller to remove pipeline from contact

Add strong params for destroy action

Add To Pipeline now persists contact's new pipeline in db

Fix route issue
